### PR TITLE
Shows expire option in days when it is a multiple of 24 hours

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -262,7 +262,13 @@
               name="expires"
               class="mx-1 rounded-md border-0 bg-white/5 py-1.5 text-xs text-white shadow-sm ring-1 ring-inset ring-white/10 focus:ring-2 focus:ring-inset focus:ring-blue-500 md:mx-2 md:text-base [&_*]:text-black">
               {#each expireOptions as value}
-                <option {value}>{value} Hour{value > 1 ? 's' : ''}</option>
+                <option {value}>
+                  {#if value > 24 && value % 24 === 0}
+                    {value / 24} Days
+                  {:else}
+                    {value} Hour{value > 1 ? 's' : ''}
+                  {/if}
+                </option>
               {/each}
             </select>
             or


### PR DESCRIPTION
Motivation: If you want to have an expire period of multiple days, it is inconvenient if they are shown as the number of hours. So we use days as a unit in that case.