### PR TITLE
Add docker compose setup for running in containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ Once you've setup your production environment, ensure you've enabled CORS as not
 npm run build
 ```
 
+## Running in Docker
+
+There is an example configuration for running 0up in a Docker Compose-based setup in the the `docker` subdirectory.
+
 ### Cleanup Cron Job
 
 A database cleanup cronjob (`GET https://your.host.here/api/cron/cleanup`) can be called at regular intervals to purge expired data from the database. The request requires an `Authorization` header with the value you've set in your .env file under `PRIVATE_CRON_SECRET`. You may use a service like [Pipedream](https://pipedream.com) for this, or simply create a cronjob to run a command like:

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,2 @@
+/.env*
+/docker

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:20
+
+RUN mkdir /home/node/app \
+ && chown node:node /home/node/app
+USER node
+WORKDIR /home/node/app
+
+COPY --chown=node:node package.json package-lock.json ./
+RUN npm install
+RUN npm i -D @sveltejs/adapter-node@1.3.1
+
+COPY --chown=node:node . ./
+
+COPY --chown=node:node docker/docker-entrypoint.sh /
+
+RUN sed -i 's/adapter-auto/adapter-node/' svelte.config.js
+
+RUN npx prisma generate
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["node", "build"]
+EXPOSE 3000/tcp
+
+HEALTHCHECK --interval=15s --timeout=3s --start-period=25s --retries=2 \
+  CMD curl -f http://localhost:3000/privacy || exit 1

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    env_file: ../.env
+    environment:
+      - PRIVATE_DATABASE_URL=postgresql://postgres:password@database:5432/postgres
+    ports:
+      - 3000:3000/tcp
+    depends_on:
+      - database
+
+  cleanup:
+    image: curlimages/curl:8.6.0
+    env_file: ../.env
+    command: ["sh", "-c", "while true; do echo \"Cleaning up\"; curl -H \"Authorization: $PRIVATE_CRON_SECRET\" http://app:3000/api/cron/cleanup; sleep 600; done"]
+    depends_on:
+      - app
+
+  database:
+    image: postgres:16
+    environment:
+      POSTGRES_PASSWORD: password

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+npm run build
+
+exec "$@"


### PR DESCRIPTION
It was a bit complicated to get this working

a) without baking env secrets into the container image and
b) switching the svelte adapter so the app can run a standalone server

I guess the adapter switching in `svelte.config.js` could also be done via an env setting, but this can also be done later.